### PR TITLE
Set the Host header to the original request's Host header.

### DIFF
--- a/nginx/conf.d/02-https.conf
+++ b/nginx/conf.d/02-https.conf
@@ -9,6 +9,7 @@ server {
   ssl_certificate_key /etc/nginx/key.pem;
 
   location / {
+      proxy_set_header Host $host;
       proxy_pass http://backend;
   }
 }


### PR DESCRIPTION
Without this change the Host header to the backend is `backend`.

Setting Host to the original request's Host header seems more generally useful.

Fixes flaccid/docker-tls-proxy#1